### PR TITLE
Fix wrong gem name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Built-in metrics for [Sidekiq] monitoring out of the box! Part of the [yabeda] s
 ## Installation
 
 ```ruby
-gem 'yabeda-rails'
+gem 'yabeda-sidekiq'
 # Then add monitoring system adapter, e.g.:
 # gem 'yabeda-prometheus'
 ```


### PR DESCRIPTION
README mentions wrong gem name, leading to an empty page served at `localhost:9394/metrics` 