### PR TITLE
Monitor sidekiq process used memory

### DIFF
--- a/lib/yabeda/sidekiq.rb
+++ b/lib/yabeda/sidekiq.rb
@@ -52,7 +52,7 @@ module Yabeda
           sidekiq_jobs_latency.set({ queue: queue.name }, queue.latency)
         end
 
-        sidekiq_memory_usage = Yabeda::Sidekiq.process_memory_usage
+        sidekiq_memory_usage.set({}, Yabeda::Sidekiq.process_memory_usage)
 
         # That is quite slow if your retry set is large
         # I don't want to enable it by default

--- a/lib/yabeda/sidekiq.rb
+++ b/lib/yabeda/sidekiq.rb
@@ -21,7 +21,6 @@ module Yabeda
       counter :jobs_enqueued_total, comment: "A counter of the total number of jobs sidekiq enqueued."
 
       next unless ::Sidekiq.server?
-
       counter   :jobs_executed_total,  comment: "A counter of the total number of jobs sidekiq executed."
       counter   :jobs_success_total,   comment: "A counter of the total number of jobs successfully processed by sidekiq."
       counter   :jobs_failed_total,    comment: "A counter of the total number of jobs failed in sidekiq."
@@ -97,7 +96,7 @@ module Yabeda
       def process_memory_usage
         memories = Hash[%i{size resident shared trs lrs drs dt}.zip(open("/proc/#{Process.pid}/statm").read.split)]
         page_size = `getconf PAGESIZE`.chomp.to_i
-        memories[:resident] * page_size
+        memories[:resident].to_i * page_size
       end
     end
   end


### PR DESCRIPTION
Hey! In Amplifr we have some issues with sidekiq memory overlimit, so this metrics is to monitor overall memory, which is used by sidekiq process