### PR TITLE
Job latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ end
  - Number of jobs have been finished successfully: `sidekiq_jobs_success_total` (segmented by queue and class name)
  - Number of jobs have been failed: `sidekiq_jobs_failed_total` (segmented by queue and class name)
  - Time of job run: `sidekiq_job_runtime` (seconds per job execution, segmented by queue and class name)
- - Time of the queue latency `sidekiq_jobs_latency` (the difference in seconds since the oldest job in the queue was enqueued)
+ - Time of the queue latency `sidekiq_queue_latency` (the difference in seconds since the oldest job in the queue was enqueued)
+ - Time of the job latency `sidekiq_job_latency` (the difference in seconds since the enqueuing until running job)
  - Number of jobs in queues: `sidekiq_jobs_waiting_count` (segmented by queue)
  - Number of scheduled jobs:`sidekiq_jobs_scheduled_count`
  - Number of jobs in retry set: `sidekiq_jobs_retry_count`

--- a/lib/yabeda/sidekiq.rb
+++ b/lib/yabeda/sidekiq.rb
@@ -26,7 +26,6 @@ module Yabeda
       counter   :jobs_success_total,   tags: %i[queue worker], comment: "A counter of the total number of jobs successfully processed by sidekiq."
       counter   :jobs_failed_total,    tags: %i[queue worker], comment: "A counter of the total number of jobs failed in sidekiq."
 
-      gauge     :job_latency,          tags: %i[queue worker], comment: "The job latency, the difference in seconds between enqueued and running time"
       gauge     :jobs_waiting_count,   tags: %i[queue], comment: "The number of jobs waiting to process in sidekiq."
       gauge     :active_workers_count, tags: [],        comment: "The number of currently running machines with sidekiq workers."
       gauge     :jobs_scheduled_count, tags: [],        comment: "The number of jobs scheduled for later execution."
@@ -35,6 +34,10 @@ module Yabeda
       gauge     :active_processes,     tags: [],        comment: "The number of active Sidekiq worker processes."
       gauge     :queue_latency,        tags: %i[queue], comment: "The queue latency, the difference in seconds since the oldest job in the queue was enqueued"
 
+      histogram :job_latency, comment: "The job latency, the difference in seconds between enqueued and running time",
+                              unit: :seconds, per: :job,
+                              tags: %i[queue worker],
+                              buckets: LONG_RUNNING_JOB_RUNTIME_BUCKETS
       histogram :job_runtime, comment: "A histogram of the job execution time.",
                               unit: :seconds, per: :job,
                               tags: %i[queue worker],

--- a/lib/yabeda/sidekiq.rb
+++ b/lib/yabeda/sidekiq.rb
@@ -53,7 +53,7 @@ module Yabeda
         sidekiq_jobs_retry_count.set({}, stats.retry_size)
 
         ::Sidekiq::Queue.all.each do |queue|
-          sidekiq_jobs_latency.set({ queue: queue.name }, queue.latency)
+          sidekiq_queue_latency.set({ queue: queue.name }, queue.latency)
         end
 
         # That is quite slow if your retry set is large

--- a/lib/yabeda/sidekiq.rb
+++ b/lib/yabeda/sidekiq.rb
@@ -26,13 +26,14 @@ module Yabeda
       counter   :jobs_success_total,   tags: %i[queue worker], comment: "A counter of the total number of jobs successfully processed by sidekiq."
       counter   :jobs_failed_total,    tags: %i[queue worker], comment: "A counter of the total number of jobs failed in sidekiq."
 
+      gauge     :job_latency,          tags: %i[queue worker], comment: "The job latency, the difference in seconds between enqueued and running time"
       gauge     :jobs_waiting_count,   tags: %i[queue], comment: "The number of jobs waiting to process in sidekiq."
       gauge     :active_workers_count, tags: [],        comment: "The number of currently running machines with sidekiq workers."
       gauge     :jobs_scheduled_count, tags: [],        comment: "The number of jobs scheduled for later execution."
       gauge     :jobs_retry_count,     tags: [],        comment: "The number of failed jobs waiting to be retried"
       gauge     :jobs_dead_count,      tags: [],        comment: "The number of jobs exceeded their retry count."
       gauge     :active_processes,     tags: [],        comment: "The number of active Sidekiq worker processes."
-      gauge     :jobs_latency,         tags: %i[queue], comment: "The job latency, the difference in seconds since the oldest job in the queue was enqueued"
+      gauge     :queue_latency,        tags: %i[queue], comment: "The queue latency, the difference in seconds since the oldest job in the queue was enqueued"
 
       histogram :job_runtime, comment: "A histogram of the job execution time.",
                               unit: :seconds, per: :job,

--- a/lib/yabeda/sidekiq/server_middleware.rb
+++ b/lib/yabeda/sidekiq/server_middleware.rb
@@ -8,6 +8,7 @@ module Yabeda
         labels = Yabeda::Sidekiq.labelize(worker, job, queue)
         start = Time.now
         begin
+          Yabeda.sidekiq_job_latency.measure(labels, job.latency)
           yield
           Yabeda.sidekiq_jobs_success_total.increment(labels)
         rescue Exception # rubocop: disable Lint/RescueException

--- a/lib/yabeda/sidekiq/server_middleware.rb
+++ b/lib/yabeda/sidekiq/server_middleware.rb
@@ -8,7 +8,7 @@ module Yabeda
         labels = Yabeda::Sidekiq.labelize(worker, job, queue)
         start = Time.now
         begin
-          job_instance = Sidekiq::Job.new(job)
+          job_instance = ::Sidekiq::Job.new(job)
           Yabeda.sidekiq_job_latency.measure(labels, job_instance.latency)
           yield
           Yabeda.sidekiq_jobs_success_total.increment(labels)

--- a/lib/yabeda/sidekiq/server_middleware.rb
+++ b/lib/yabeda/sidekiq/server_middleware.rb
@@ -8,7 +8,8 @@ module Yabeda
         labels = Yabeda::Sidekiq.labelize(worker, job, queue)
         start = Time.now
         begin
-          Yabeda.sidekiq_job_latency.measure(labels, job.latency)
+          job_instance = Sidekiq::Job.new(job)
+          Yabeda.sidekiq_job_latency.measure(labels, job_instance.latency)
           yield
           Yabeda.sidekiq_jobs_success_total.increment(labels)
         rescue Exception # rubocop: disable Lint/RescueException


### PR DESCRIPTION
### What do this PR do?

- added new metric for latency of job - time difference between enqueuing and running of job
- renamed metric for latency of queue

### Purposes
#### Why metric renamed?
We set metric's value from property of `Sidekiq::Queue` instance, so I think the new name is accurately determines its value

