### PR TITLE
Monitor worker job runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ end
  - Number of jobs in dead set (“morgue”): `sidekiq_jobs_dead_count`
  - Active workers count: `sidekiq_active_processes`
  - Active processes count: `sidekiq_active_workers_count`
+ - Runtime of the actual running worker jobs `sidekiq_worker_runtime`
 
 ## Custom tags
 

--- a/lib/yabeda/sidekiq.rb
+++ b/lib/yabeda/sidekiq.rb
@@ -33,7 +33,7 @@ module Yabeda
       gauge     :jobs_dead_count,      tags: [],        comment: "The number of jobs exceeded their retry count."
       gauge     :active_processes,     tags: [],        comment: "The number of active Sidekiq worker processes."
       gauge     :queue_latency,        tags: %i[queue], comment: "The queue latency, the difference in seconds since the oldest job in the queue was enqueued"
-      gauge     :job_max_runtime,    tags: %i[queue worker], comment: "The actual job runtime"
+      gauge     :job_max_runtime,      tags: %i[queue worker], comment: "The actual job runtime"
 
       histogram :job_latency, comment: "The job latency, the difference in seconds between enqueued and running time",
                               unit: :seconds, per: :job,
@@ -60,7 +60,7 @@ module Yabeda
           sidekiq_queue_latency.set({ queue: queue.name }, queue.latency)
         end
 
-        track_job_max_runtime
+        Yabeda::Sidekiq.track_job_max_runtime
         # That is quite slow if your retry set is large
         # I don't want to enable it by default
         # retries_by_queues =
@@ -89,7 +89,7 @@ module Yabeda
     end
 
     class << self
-      att_accessor :job_tags
+      attr_accessor :job_tags
 
       def labelize(worker, job, queue)
         { queue: queue, worker: worker_class(worker, job), **custom_tags(worker, job).to_h }
@@ -111,20 +111,22 @@ module Yabeda
 
     self.job_tags = []
 
-    def track_job_max_runtime
+    # rubocop: disable Metrics/AbcSize
+    def self.track_job_max_runtime
       now = Time.now.utc
-      workers_runtime = ::Sidekiq::Workers.new.each_with_object do |result, (process, thread, msg)|
-        payload = msg['payload']
-        tags = {queue: payload['queue'], worker: payload['class']}
+      workers_runtime = ::Sidekiq::Workers.new.each_with_object({}) do |result, (_process, _thread, msg)|
+        payload = msg["payload"]
+        tags = { queue: payload["queue"], worker: payload["class"] }
         job_tags << tags unless job_tags.include?(tags)
 
-        duration = now - Time.at(msg['run_at'])
+        duration = now - Time.at(msg["run_at"])
         result[tags] = duration if !result[tags] || result[tags] < duration
       end
 
-      job_tags.each_with_object({}).each do |result, tags|
+      job_tags.each_with_object({}).each do |_result, tags|
         job_max_runtime.set(tags, workers_runtime[tags].to_i)
       end
     end
+    # rubocop: enable Metrics/AbcSize
   end
 end

--- a/lib/yabeda/sidekiq.rb
+++ b/lib/yabeda/sidekiq.rb
@@ -33,7 +33,7 @@ module Yabeda
       gauge     :jobs_dead_count,      tags: [],        comment: "The number of jobs exceeded their retry count."
       gauge     :active_processes,     tags: [],        comment: "The number of active Sidekiq worker processes."
       gauge     :queue_latency,        tags: %i[queue], comment: "The queue latency, the difference in seconds since the oldest job in the queue was enqueued"
-      gauge     :worker_runtime,       tags: %i[queue worker jid], comment: "The actual worker job runtime"
+      gauge     :worker_runtime,       tags: %i[queue worker], comment: "The actual worker job runtime"
 
       histogram :job_latency, comment: "The job latency, the difference in seconds between enqueued and running time",
                               unit: :seconds, per: :job,
@@ -65,7 +65,7 @@ module Yabeda
           payload = msg['payload']
 
           sidekiq_worker_runtime.set(
-            {queue: payload['queue'], worker: payload['class'], jid: payload['jid']},
+            {queue: payload['queue'], worker: payload['class']},
             now - Time.at(msg['run_at'])
           )
         end

--- a/spec/yabeda/sidekiq_spec.rb
+++ b/spec/yabeda/sidekiq_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Yabeda::Sidekiq do
   before do
     allow(Sidekiq::Stats).to receive(:new).and_return(
-      OpenStruct.new({
+      OpenStruct.new(
         workers_size: 0,
         scheduled_size: 0,
         dead_size: 0,
@@ -12,11 +12,13 @@ RSpec.describe Yabeda::Sidekiq do
         processed: 0,
         failed: 0,
         queues: { "default" => 0 },
-      })
+      ),
     )
-    allow(Sidekiq::Queue).to receive(:all).and_return([
-      OpenStruct.new({ name: "default", latency: 0 }),
-    ])
+    allow(Sidekiq::Queue).to receive(:all).and_return(
+      [
+        OpenStruct.new({ name: "default", latency: 0 }),
+      ],
+    )
   end
 
   it "has a version number" do

--- a/spec/yabeda/sidekiq_spec.rb
+++ b/spec/yabeda/sidekiq_spec.rb
@@ -1,6 +1,24 @@
 # frozen_string_literal: true
 
 RSpec.describe Yabeda::Sidekiq do
+  before do
+    allow(Sidekiq::Stats).to receive(:new).and_return(
+      OpenStruct.new({
+        workers_size: 0,
+        scheduled_size: 0,
+        dead_size: 0,
+        processes_size: 0,
+        retry_size: 0,
+        processed: 0,
+        failed: 0,
+        queues: { "default" => 0 },
+      })
+    )
+    allow(Sidekiq::Queue).to receive(:all).and_return([
+      OpenStruct.new({ name: "default", latency: 0 }),
+    ])
+  end
+
   it "has a version number" do
     expect(Yabeda::Sidekiq::VERSION).not_to be nil
   end


### PR DESCRIPTION
Hi, useful metrics to keep track of the current running job runtime (see the "busy" section in the sidekiq admin panel).
This is monstly for alerting to determine time-consuming jobs with the following alert rule:

For example publication* job running more than 10 minutes:

```
max(sidekiq_worker_runtime{queue=~"publication.*"}) by (queue) > 600
```
