### PR TITLE
Track maximum runtime of currently running jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ end
  - Number of jobs in dead set (“morgue”): `sidekiq_jobs_dead_count`
  - Active workers count: `sidekiq_active_processes`
  - Active processes count: `sidekiq_active_workers_count`
+ - Maximum runtime of currently executing jobs: `sidekiq_running_job_runtime` (useful for detection of hung jobs, segmented by queue and class name)
 
 ## Custom tags
 

--- a/lib/yabeda/sidekiq/server_middleware.rb
+++ b/lib/yabeda/sidekiq/server_middleware.rb
@@ -12,6 +12,7 @@ module Yabeda
         begin
           job_instance = ::Sidekiq::Job.new(job)
           Yabeda.sidekiq_job_latency.measure(labels, job_instance.latency)
+          Yabeda::Sidekiq.jobs_started_at[labels][job["jid"]] = start
           Yabeda.with_tags(**custom_tags) do
             yield
           end
@@ -22,6 +23,7 @@ module Yabeda
         ensure
           Yabeda.sidekiq_job_runtime.measure(labels, elapsed(start))
           Yabeda.sidekiq_jobs_executed_total.increment(labels)
+          Yabeda::Sidekiq.jobs_started_at[labels].delete(job["jid"])
         end
       end
       # rubocop: enable Metrics/AbcSize, Metrics/MethodLength:

--- a/spec/support/jobs.rb
+++ b/spec/support/jobs.rb
@@ -8,6 +8,15 @@ class SamplePlainJob
   end
 end
 
+class SampleLongRunningJob
+  include Sidekiq::Worker
+
+  def perform(*_args)
+    sleep 0.05
+    "Phew, I'm done!"
+  end
+end
+
 class SampleComplexJob
   include Sidekiq::Worker
 

--- a/spec/support/sidekiq_inline_middlewares.rb
+++ b/spec/support/sidekiq_inline_middlewares.rb
@@ -7,6 +7,7 @@ module SidekiqTestingInlineWithMiddlewares
     return super unless Sidekiq::Testing.inline?
 
     job = Sidekiq.load_json(Sidekiq.dump_json(job))
+    job["jid"] ||= SecureRandom.hex(12)
     job_class = Sidekiq::Testing.constantize(job["class"])
     job_instance = job_class.new
     queue = (job_instance.sidekiq_options_hash || {}).fetch("queue", "default")

--- a/spec/yabeda/sidekiq_spec.rb
+++ b/spec/yabeda/sidekiq_spec.rb
@@ -175,15 +175,15 @@ RSpec.describe Yabeda::Sidekiq do
       Sidekiq::Testing.inline! do
         workers = []
         workers.push(Thread.new { SampleLongRunningJob.perform_async })
-        sleep 0.01
+        sleep 0.012 # Ruby can sleep less than requested
         workers.push(Thread.new { SampleLongRunningJob.perform_async })
 
         Yabeda.collectors.each(&:call)
         expect(Yabeda.sidekiq.running_job_runtime.values).to include(
-          { queue: "default", worker: "SampleLongRunningJob" } => (be >= 0.01),
+          { queue: "default", worker: "SampleLongRunningJob" } => (be >= 0.010),
         )
 
-        sleep 0.01
+        sleep 0.012 # Ruby can sleep less than requested
         begin
           FailingActiveJob.perform_later
         rescue StandardError
@@ -192,7 +192,7 @@ RSpec.describe Yabeda::Sidekiq do
         Yabeda.collectors.each(&:call)
 
         expect(Yabeda.sidekiq.running_job_runtime.values).to include(
-          { queue: "default", worker: "SampleLongRunningJob" } => (be >= 0.02),
+          { queue: "default", worker: "SampleLongRunningJob" } => (be >= 0.020),
           { queue: "default", worker: "FailingActiveJob" } => 0,
         )
 


### PR DESCRIPTION
This is alternative implementation of #13 without querying Redis.

The goal:
> useful metrics to keep track of the current running job runtime (see the "busy" section in the sidekiq admin panel).
> This is mostly for alerting to determine time-consuming jobs

However, in implementation in #13 each Sidekiq worker executes query to Redis on each `collect` block execution, retrieves info about all executing jobs in all Sidekiq processes and single process reports not only its own stats, but also stats for every other worker. On large Sidekiq installations (with dozens processes executing hundreds of jobs at a time) it may be painful.

In this pull request, every worker process keeps track and reports runtime duration only for its own jobs in memory and doesn't any additional requests to Redis.