### PR TITLE
Allow to disable collection of general metrics (of the whole Sidekiq setup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
- - Setting `collect_general_metrics` allowing to opt-out from collecting of whole Sidekiq installaction-wide metrics. See [#20](https://github.com/yabeda-rb/yabeda-sidekiq/pull/20). [@mrexox]
+ - Setting `collect_general_metrics` allowing to opt-out from collecting of whole Sidekiq installaction-wide metrics. Setting `collect_server_metrics` allowing to force collecting metrics even if the instance is not a Sidekiq server. See [#20](https://github.com/yabeda-rb/yabeda-sidekiq/pull/20). [@mrexox]
 
 ## 0.7.0 - 2020-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
- - Setting `collect_general_metrics` allowing to opt-out from collecting of whole Sidekiq installaction-wide metrics. Setting `collect_server_metrics` allowing to force collecting metrics even if the instance is not a Sidekiq server. See [#20](https://github.com/yabeda-rb/yabeda-sidekiq/pull/20). [@mrexox]
+ - Setting `collect_general_metrics` allowing to force enable or disable collection of global (whole Sidekiq installaction-wide) metrics. See [#20](https://github.com/yabeda-rb/yabeda-sidekiq/pull/20). [@mrexox]
+
+    By default all sidekiq worker processes (servers) collects global metrics about whole Sidekiq installation.
+    Client processes (everything else that is not Sidekiq worker) by default doesn't.
+
+    With this config you can override this behavior:
+    - force disable if you don't want multiple Sidekiq workers to report the same numbers (that causes excess load to both Redis and monitoring)
+    - force enable if you want non-Sidekiq process to collect them (like dedicated metric exporter process)
 
 ## 0.7.0 - 2020-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
- - Setting `collect_global_metrics` allowing to force enable or disable collection of global (whole Sidekiq installaction-wide) metrics. See [#20](https://github.com/yabeda-rb/yabeda-sidekiq/pull/20). [@mrexox]
+ - Setting `collect_cluster_metrics` allowing to force enable or disable collection of global (whole Sidekiq installaction-wide) metrics. See [#20](https://github.com/yabeda-rb/yabeda-sidekiq/pull/20). [@mrexox]
 
     By default all sidekiq worker processes (servers) collects global metrics about whole Sidekiq installation.
     Client processes (everything else that is not Sidekiq worker) by default doesn't.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
- - Setting `collect_general_metrics` allowing to force enable or disable collection of global (whole Sidekiq installaction-wide) metrics. See [#20](https://github.com/yabeda-rb/yabeda-sidekiq/pull/20). [@mrexox]
+ - Setting `collect_global_metrics` allowing to force enable or disable collection of global (whole Sidekiq installaction-wide) metrics. See [#20](https://github.com/yabeda-rb/yabeda-sidekiq/pull/20). [@mrexox]
 
     By default all sidekiq worker processes (servers) collects global metrics about whole Sidekiq installation.
     Client processes (everything else that is not Sidekiq worker) by default doesn't.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 0.8.0 - 2021-05-07
-
 ### Added
 
- - Add env variable YABEDA_SIDEKIQ_GENERAL_METRICS_DISABLE to control collecting of common metrics. See [#20](https://github.com/yabeda-rb/yabeda-sidekiq/pull/20). [@mrexox]
+ - Setting `collect_general_metrics` allowing to opt-out from collecting of whole Sidekiq installaction-wide metrics. See [#20](https://github.com/yabeda-rb/yabeda-sidekiq/pull/20). [@mrexox]
 
 ## 0.7.0 - 2020-07-15
 
@@ -69,3 +67,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [@dsalahutdinov]: https://github.com/dsalahutdinov "Salahutdinov Dmitry"
 [@asusikov]: https://github.com/asusikov "Alexander Susikov"
+[@mrexox]: https://github.com/mrexox "Valentine Kiselev"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 - 2021-05-07
+
+### Added
+
+ - Add env variable YABEDA_SIDEKIQ_GENERAL_METRICS_DISABLE to control collecting of common metrics. See [#20](https://github.com/yabeda-rb/yabeda-sidekiq/pull/20). [@mrexox]
+
 ## 0.7.0 - 2020-07-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Metrics representing state of current Sidekiq worker process and stats of execut
 
 ### Cumulative Sidekiq metrics
 
-Metrics representing state of the whole Sidekiq installation (queues, processes, etc). These can be disabled by setting `collect_general_metrics` config key to `false` (e.g. by setting `YABEDA_SIDEKIQ_COLLECT_GENERAL_METRICS` env variable to `no`, see other methods in [anyway_config] docs):
+Metrics representing state of the whole Sidekiq installation (queues, processes, etc):
 
  - Number of jobs in queues: `sidekiq_jobs_waiting_count` (segmented by queue)
  - Time of the queue latency `sidekiq_queue_latency` (the difference in seconds since the oldest job in the queue was enqueued)
@@ -59,6 +59,8 @@ Metrics representing state of the whole Sidekiq installation (queues, processes,
  - Number of jobs in dead set (“morgue”): `sidekiq_jobs_dead_count`
  - Active processes count: `sidekiq_active_processes`
  - Active servers count: `sidekiq_active_workers_count`
+
+By default all sidekiq worker processes (servers) collects global metrics about whole Sidekiq installation. This can be overriden by setting `collect_general_metrics` config key to `true` for non-Sidekiq processes or to `false` for Sidekiq processes (e.g. by setting `YABEDA_SIDEKIQ_COLLECT_GENERAL_METRICS` env variable to `no`, see other methods in [anyway_config] docs).
 
 ## Custom tags
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ end
  - Time of job run: `sidekiq_job_runtime` (seconds per job execution, segmented by queue and class name)
  - Time of the queue latency `sidekiq_queue_latency` (the difference in seconds since the oldest job in the queue was enqueued)
  - Time of the job latency `sidekiq_job_latency` (the difference in seconds since the enqueuing until running job)
+
+These can be disabled with setting `YABEDA_SIDEKIQ_GENERAL_METRICS_DISABLE=1`:
+
  - Number of jobs in queues: `sidekiq_jobs_waiting_count` (segmented by queue)
  - Number of scheduled jobs:`sidekiq_jobs_scheduled_count`
  - Number of jobs in retry set: `sidekiq_jobs_retry_count`

--- a/README.md
+++ b/README.md
@@ -37,22 +37,28 @@ end
 
 ## Metrics
 
+### Sidekiq process metrics
+
+Metrics representing state of current Sidekiq worker process and stats of executed or executing jobs:
+
  - Total number of executed jobs: `sidekiq_jobs_executed_total` -  (segmented by queue and class name)
  - Number of jobs have been finished successfully: `sidekiq_jobs_success_total` (segmented by queue and class name)
  - Number of jobs have been failed: `sidekiq_jobs_failed_total` (segmented by queue and class name)
  - Time of job run: `sidekiq_job_runtime` (seconds per job execution, segmented by queue and class name)
- - Time of the queue latency `sidekiq_queue_latency` (the difference in seconds since the oldest job in the queue was enqueued)
  - Time of the job latency `sidekiq_job_latency` (the difference in seconds since the enqueuing until running job)
+ - Maximum runtime of currently executing jobs: `sidekiq_running_job_runtime` (useful for detection of hung jobs, segmented by queue and class name)
 
-These can be disabled with setting `YABEDA_SIDEKIQ_GENERAL_METRICS_DISABLE=1`:
+### Cumulative Sidekiq metrics
+
+Metrics representing state of the whole Sidekiq installation (queues, processes, etc). These can be disabled by setting `collect_general_metrics` config key to `false` (e.g. by setting `YABEDA_SIDEKIQ_COLLECT_GENERAL_METRICS` env variable to `no`, see other methods in [anyway_config] docs):
 
  - Number of jobs in queues: `sidekiq_jobs_waiting_count` (segmented by queue)
+ - Time of the queue latency `sidekiq_queue_latency` (the difference in seconds since the oldest job in the queue was enqueued)
  - Number of scheduled jobs:`sidekiq_jobs_scheduled_count`
  - Number of jobs in retry set: `sidekiq_jobs_retry_count`
  - Number of jobs in dead set (“morgue”): `sidekiq_jobs_dead_count`
- - Active workers count: `sidekiq_active_processes`
- - Active processes count: `sidekiq_active_workers_count`
- - Maximum runtime of currently executing jobs: `sidekiq_running_job_runtime` (useful for detection of hung jobs, segmented by queue and class name)
+ - Active processes count: `sidekiq_active_processes`
+ - Active servers count: `sidekiq_active_workers_count`
 
 ## Custom tags
 
@@ -134,3 +140,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 [Sidekiq]: https://github.com/mperham/sidekiq/ "Simple, efficient background processing for Ruby"
 [yabeda]: https://github.com/yabeda-rb/yabeda
 [yabeda-prometheus]: https://github.com/yabeda-rb/yabeda-prometheus
+[anyway_config]: https://github.com/palkan/anyway_config "Configuration library for Ruby gems and applications"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Metrics representing state of the whole Sidekiq installation (queues, processes,
  - Active processes count: `sidekiq_active_processes`
  - Active servers count: `sidekiq_active_workers_count`
 
-By default all sidekiq worker processes (servers) collects global metrics about whole Sidekiq installation. This can be overridden by setting `collect_global_metrics` config key to `true` for non-Sidekiq processes or to `false` for Sidekiq processes (e.g. by setting `YABEDA_SIDEKIQ_COLLECT_GLOBAL_METRICS` env variable to `no`, see other methods in [anyway_config] docs).
+By default all sidekiq worker processes (servers) collects global metrics about whole Sidekiq installation. This can be overridden by setting `collect_cluster_metrics` config key to `true` for non-Sidekiq processes or to `false` for Sidekiq processes (e.g. by setting `YABEDA_SIDEKIQ_COLLECT_CLUSTER_METRICS` env variable to `no`, see other methods in [anyway_config] docs).
 
 ## Custom tags
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ class MyWorker
 end
 ```
 
+## Configuration
+
+Configuration is handled by [anyway_config] gem. With it you can load settings from environment variables (upcased and prefixed with `YABEDA_SIDEKIQ_`), YAML files, and other sources. See [anyway_config] docs for details.
+
+Config key                | Type     | Default                                                 | Description |
+------------------------- | -------- | ------------------------------------------------------- | ----------- |
+`collect_cluster_metrics` | boolean  | Enabled in Sidekiq worker processes, disabled otherwise | Defines whether this Ruby process should collect and expose metrics representing state of the whole Sidekiq installation (queues, processes, etc). |
+
 # Roadmap (TODO or Help wanted)
 
  - Implement optional segmentation of retry/schedule/dead sets

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ end
 
 ## Metrics
 
-### Sidekiq process metrics
+### Local per-process metrics
 
 Metrics representing state of current Sidekiq worker process and stats of executed or executing jobs:
 
@@ -48,7 +48,7 @@ Metrics representing state of current Sidekiq worker process and stats of execut
  - Time of the job latency `sidekiq_job_latency` (the difference in seconds since the enqueuing until running job)
  - Maximum runtime of currently executing jobs: `sidekiq_running_job_runtime` (useful for detection of hung jobs, segmented by queue and class name)
 
-### Cumulative Sidekiq metrics
+### Global cluster-wide metrics
 
 Metrics representing state of the whole Sidekiq installation (queues, processes, etc):
 
@@ -60,7 +60,7 @@ Metrics representing state of the whole Sidekiq installation (queues, processes,
  - Active processes count: `sidekiq_active_processes`
  - Active servers count: `sidekiq_active_workers_count`
 
-By default all sidekiq worker processes (servers) collects global metrics about whole Sidekiq installation. This can be overriden by setting `collect_general_metrics` config key to `true` for non-Sidekiq processes or to `false` for Sidekiq processes (e.g. by setting `YABEDA_SIDEKIQ_COLLECT_GENERAL_METRICS` env variable to `no`, see other methods in [anyway_config] docs).
+By default all sidekiq worker processes (servers) collects global metrics about whole Sidekiq installation. This can be overridden by setting `collect_global_metrics` config key to `true` for non-Sidekiq processes or to `false` for Sidekiq processes (e.g. by setting `YABEDA_SIDEKIQ_COLLECT_GLOBAL_METRICS` env variable to `no`, see other methods in [anyway_config] docs).
 
 ## Custom tags
 

--- a/lib/yabeda/sidekiq.rb
+++ b/lib/yabeda/sidekiq.rb
@@ -7,6 +7,7 @@ require "yabeda"
 require "yabeda/sidekiq/version"
 require "yabeda/sidekiq/client_middleware"
 require "yabeda/sidekiq/server_middleware"
+require "yabeda/sidekiq/config"
 
 module Yabeda
   module Sidekiq
@@ -16,6 +17,8 @@ module Yabeda
     ].freeze
 
     Yabeda.configure do
+      config = Config.new
+
       group :sidekiq
 
       counter :jobs_enqueued_total, tags: %i[queue worker], comment: "A counter of the total number of jobs sidekiq enqueued."
@@ -26,13 +29,18 @@ module Yabeda
       counter   :jobs_success_total,   tags: %i[queue worker], comment: "A counter of the total number of jobs successfully processed by sidekiq."
       counter   :jobs_failed_total,    tags: %i[queue worker], comment: "A counter of the total number of jobs failed in sidekiq."
 
-      gauge     :jobs_waiting_count,   tags: %i[queue], comment: "The number of jobs waiting to process in sidekiq."
-      gauge     :active_workers_count, tags: [],        comment: "The number of currently running machines with sidekiq workers."
-      gauge     :jobs_scheduled_count, tags: [],        comment: "The number of jobs scheduled for later execution."
-      gauge     :jobs_retry_count,     tags: [],        comment: "The number of failed jobs waiting to be retried"
-      gauge     :jobs_dead_count,      tags: [],        comment: "The number of jobs exceeded their retry count."
-      gauge     :active_processes,     tags: [],        comment: "The number of active Sidekiq worker processes."
-      gauge     :queue_latency,        tags: %i[queue], comment: "The queue latency, the difference in seconds since the oldest job in the queue was enqueued"
+      # Metrics not specific for current Sidekiq process, but representing state of the whole Sidekiq installation (queues, processes, etc)
+      # You can opt-out from collecting these by setting YABEDA_SIDEKIQ_COLLECT_GENERAL_METRICS to falsy value (+no+ or +false+)
+      if config.collect_general_metrics
+        gauge     :jobs_waiting_count,   tags: %i[queue], comment: "The number of jobs waiting to process in sidekiq."
+        gauge     :active_workers_count, tags: [],        comment: "The number of currently running machines with sidekiq workers."
+        gauge     :jobs_scheduled_count, tags: [],        comment: "The number of jobs scheduled for later execution."
+        gauge     :jobs_retry_count,     tags: [],        comment: "The number of failed jobs waiting to be retried"
+        gauge     :jobs_dead_count,      tags: [],        comment: "The number of jobs exceeded their retry count."
+        gauge     :active_processes,     tags: [],        comment: "The number of active Sidekiq worker processes."
+        gauge     :queue_latency,        tags: %i[queue], comment: "The queue latency, the difference in seconds since the oldest job in the queue was enqueued"
+      end
+
       gauge     :running_job_runtime,  tags: %i[queue worker], aggregation: :max, unit: :seconds,
                                        comment: "How long currently running jobs are running (useful for detection of hung jobs)"
 
@@ -45,9 +53,11 @@ module Yabeda
                               tags: %i[queue worker],
                               buckets: LONG_RUNNING_JOB_RUNTIME_BUCKETS
 
-      next if ENV["YABEDA_SIDEKIQ_GENERAL_METRICS_DISABLE"]
-
       collect do
+        Yabeda::Sidekiq.track_max_job_runtime
+
+        next unless config.collect_general_metrics
+
         stats = ::Sidekiq::Stats.new
 
         stats.queues.each do |k, v|
@@ -62,8 +72,6 @@ module Yabeda
         ::Sidekiq::Queue.all.each do |queue|
           sidekiq_queue_latency.set({ queue: queue.name }, queue.latency)
         end
-
-        Yabeda::Sidekiq.track_max_job_runtime
 
         # That is quite slow if your retry set is large
         # I don't want to enable it by default

--- a/lib/yabeda/sidekiq.rb
+++ b/lib/yabeda/sidekiq.rb
@@ -23,7 +23,9 @@ module Yabeda
 
       counter :jobs_enqueued_total, tags: %i[queue worker], comment: "A counter of the total number of jobs sidekiq enqueued."
 
-      next unless ::Sidekiq.server?
+      # By default further metrics are registered only for Sidekiq runners
+      # You can force collecting these metrics with setting YABEDA_SIDEKIQ_COLLECT_SERVER_METRICS to truthy value (+yes+ or +true+)
+      next unless config.collect_server_metrics
 
       counter   :jobs_executed_total,  tags: %i[queue worker], comment: "A counter of the total number of jobs sidekiq executed."
       counter   :jobs_success_total,   tags: %i[queue worker], comment: "A counter of the total number of jobs successfully processed by sidekiq."

--- a/lib/yabeda/sidekiq.rb
+++ b/lib/yabeda/sidekiq.rb
@@ -42,8 +42,8 @@ module Yabeda
       end
 
       # Metrics not specific for current Sidekiq process, but representing state of the whole Sidekiq installation (queues, processes, etc)
-      # You can opt-out from collecting these by setting YABEDA_SIDEKIQ_COLLECT_GLOBAL_METRICS to falsy value (+no+ or +false+)
-      if config.collect_global_metrics # defaults to +::Sidekiq.server?+
+      # You can opt-out from collecting these by setting YABEDA_SIDEKIQ_COLLECT_CLUSTER_METRICS to falsy value (+no+ or +false+)
+      if config.collect_cluster_metrics # defaults to +::Sidekiq.server?+
         gauge     :jobs_waiting_count,   tags: %i[queue], comment: "The number of jobs waiting to process in sidekiq."
         gauge     :active_workers_count, tags: [],        comment: "The number of currently running machines with sidekiq workers."
         gauge     :jobs_scheduled_count, tags: [],        comment: "The number of jobs scheduled for later execution."
@@ -56,7 +56,7 @@ module Yabeda
       collect do
         Yabeda::Sidekiq.track_max_job_runtime if ::Sidekiq.server?
 
-        next unless config.collect_global_metrics
+        next unless config.collect_cluster_metrics
 
         stats = ::Sidekiq::Stats.new
 

--- a/lib/yabeda/sidekiq.rb
+++ b/lib/yabeda/sidekiq.rb
@@ -45,6 +45,8 @@ module Yabeda
                               tags: %i[queue worker],
                               buckets: LONG_RUNNING_JOB_RUNTIME_BUCKETS
 
+      next if ENV["YABEDA_SIDEKIQ_GENERAL_METRICS_DISABLE"]
+
       collect do
         stats = ::Sidekiq::Stats.new
 

--- a/lib/yabeda/sidekiq.rb
+++ b/lib/yabeda/sidekiq.rb
@@ -42,8 +42,8 @@ module Yabeda
       end
 
       # Metrics not specific for current Sidekiq process, but representing state of the whole Sidekiq installation (queues, processes, etc)
-      # You can opt-out from collecting these by setting YABEDA_SIDEKIQ_COLLECT_GENERAL_METRICS to falsy value (+no+ or +false+)
-      if config.collect_general_metrics # defaults to +::Sidekiq.server?+
+      # You can opt-out from collecting these by setting YABEDA_SIDEKIQ_COLLECT_GLOBAL_METRICS to falsy value (+no+ or +false+)
+      if config.collect_global_metrics # defaults to +::Sidekiq.server?+
         gauge     :jobs_waiting_count,   tags: %i[queue], comment: "The number of jobs waiting to process in sidekiq."
         gauge     :active_workers_count, tags: [],        comment: "The number of currently running machines with sidekiq workers."
         gauge     :jobs_scheduled_count, tags: [],        comment: "The number of jobs scheduled for later execution."
@@ -56,7 +56,7 @@ module Yabeda
       collect do
         Yabeda::Sidekiq.track_max_job_runtime if ::Sidekiq.server?
 
-        next unless config.collect_general_metrics
+        next unless config.collect_global_metrics
 
         stats = ::Sidekiq::Stats.new
 

--- a/lib/yabeda/sidekiq/config.rb
+++ b/lib/yabeda/sidekiq/config.rb
@@ -1,0 +1,11 @@
+require "anyway"
+
+module Yabeda
+  module Sidekiq
+    class Config < ::Anyway::Config
+      config_name :yabeda_sidekiq
+
+      attr_config collect_general_metrics: true
+    end
+  end
+end

--- a/lib/yabeda/sidekiq/config.rb
+++ b/lib/yabeda/sidekiq/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "anyway"
 
 module Yabeda

--- a/lib/yabeda/sidekiq/config.rb
+++ b/lib/yabeda/sidekiq/config.rb
@@ -8,6 +8,7 @@ module Yabeda
       config_name :yabeda_sidekiq
 
       attr_config collect_general_metrics: true
+      attr_config collect_server_metrics: ::Sidekiq.server?
     end
   end
 end

--- a/lib/yabeda/sidekiq/config.rb
+++ b/lib/yabeda/sidekiq/config.rb
@@ -12,7 +12,7 @@ module Yabeda
       # With this config you can override this behavior:
       #  - force disable if you don't want multiple Sidekiq workers to report the same numbers (that causes excess load to both Redis and monitoring)
       #  - force enable if you want non-Sidekiq process to collect them (like dedicated metric exporter process)
-      attr_config collect_general_metrics: ::Sidekiq.server?
+      attr_config collect_global_metrics: ::Sidekiq.server?
     end
   end
 end

--- a/lib/yabeda/sidekiq/config.rb
+++ b/lib/yabeda/sidekiq/config.rb
@@ -12,7 +12,7 @@ module Yabeda
       # With this config you can override this behavior:
       #  - force disable if you don't want multiple Sidekiq workers to report the same numbers (that causes excess load to both Redis and monitoring)
       #  - force enable if you want non-Sidekiq process to collect them (like dedicated metric exporter process)
-      attr_config collect_global_metrics: ::Sidekiq.server?
+      attr_config collect_cluster_metrics: ::Sidekiq.server?
     end
   end
 end

--- a/lib/yabeda/sidekiq/config.rb
+++ b/lib/yabeda/sidekiq/config.rb
@@ -7,8 +7,12 @@ module Yabeda
     class Config < ::Anyway::Config
       config_name :yabeda_sidekiq
 
-      attr_config collect_general_metrics: true
-      attr_config collect_server_metrics: ::Sidekiq.server?
+      # By default all sidekiq worker processes (servers) collects global metrics about whole Sidekiq installation.
+      # Client processes (everything else that is not Sidekiq worker) by default doesn't.
+      # With this config you can override this behavior:
+      #  - force disable if you don't want multiple Sidekiq workers to report the same numbers (that causes excess load to both Redis and monitoring)
+      #  - force enable if you want non-Sidekiq process to collect them (like dedicated metric exporter process)
+      attr_config collect_general_metrics: ::Sidekiq.server?
     end
   end
 end

--- a/lib/yabeda/sidekiq/version.rb
+++ b/lib/yabeda/sidekiq/version.rb
@@ -2,6 +2,6 @@
 
 module Yabeda
   module Sidekiq
-    VERSION = "0.7.0"
+    VERSION = "0.8.0"
   end
 end

--- a/lib/yabeda/sidekiq/version.rb
+++ b/lib/yabeda/sidekiq/version.rb
@@ -2,6 +2,6 @@
 
 module Yabeda
   module Sidekiq
-    VERSION = "0.8.0"
+    VERSION = "0.7.0"
   end
 end

--- a/yabeda-sidekiq.gemspec
+++ b/yabeda-sidekiq.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "sidekiq"
   spec.add_dependency "yabeda", "~> 0.6"
+  spec.add_dependency "anyway_config", ">= 1.3", "< 3"
 
   spec.add_development_dependency "activejob", ">= 6.0"
   spec.add_development_dependency "bundler", "~> 2.0"

--- a/yabeda-sidekiq.gemspec
+++ b/yabeda-sidekiq.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "anyway_config", ">= 1.3", "< 3"
   spec.add_dependency "sidekiq"
   spec.add_dependency "yabeda", "~> 0.6"
-  spec.add_dependency "anyway_config", ">= 1.3", "< 3"
 
   spec.add_development_dependency "activejob", ">= 6.0"
   spec.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
If you run Kubernetes and have several pods running sidekiq, these general metrics can be overkill. So it is better to choose one pod that will publish these metrics instead of all pods publishing the same values.

To make it simple, I offer the solution with ENV variable checking. But I am open to discussion about how to make it more accurate.

UPD: Also added the setting to force collecting metrics even if an application is not a Sidekiq runner. 