### PR TITLE
Use Concurrent::Map instead of Concurrent::Hash

### DIFF
--- a/lib/yabeda/sidekiq.rb
+++ b/lib/yabeda/sidekiq.rb
@@ -135,6 +135,6 @@ module Yabeda
       end
     end
 
-    self.jobs_started_at = Concurrent::Hash.new { |hash, key| hash[key] = Concurrent::Hash.new }
+    self.jobs_started_at = Concurrent::Map.new { |hash, key| hash[key] = Concurrent::Map.new }
   end
 end


### PR DESCRIPTION
ruby-concurrency [recommend](https://ruby-concurrency.github.io/concurrent-ruby/1.1.4/Concurrent/Map.html) using Concurrent::Map instead of Concurrent::Hash.