### PR TITLE
Use job['queue'] param for tracking enqueued jobs, track rerouted jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Metrics representing state of current Sidekiq worker process and stats of execut
  - Time of job run: `sidekiq_job_runtime` (seconds per job execution, segmented by queue and class name)
  - Time of the job latency `sidekiq_job_latency` (the difference in seconds since the enqueuing until running job)
  - Maximum runtime of currently executing jobs: `sidekiq_running_job_runtime` (useful for detection of hung jobs, segmented by queue and class name)
+ - Total number enqueued jobs: `sidekiq_jobs_enqueued_total_count` (segmented by queue and class name)
+ - Total number rerouted jobs: `sidekiq_jobs_rerouted_total_count` (segmented by origin queue (from_queue), rerouted queue (to_queue) and class name)
 
 ### Global cluster-wide metrics
 

--- a/lib/yabeda/sidekiq.rb
+++ b/lib/yabeda/sidekiq.rb
@@ -26,7 +26,7 @@ module Yabeda
       group :sidekiq
 
       counter :jobs_enqueued_total, tags: %i[queue worker], comment: "A counter of the total number of jobs sidekiq enqueued."
-      counter :jobs_rerouted_total, tags: %i[queue worker], comment: "A counter of the total number of rerouted jobs sidekiq enqueued."
+      counter :jobs_rerouted_total, tags: %i[from_queue to_queue worker], comment: "A counter of the total number of rerouted jobs sidekiq enqueued."
 
       if config.declare_process_metrics # defaults to +::Sidekiq.server?+
         counter   :jobs_executed_total,  tags: %i[queue worker], comment: "A counter of the total number of jobs sidekiq executed."

--- a/lib/yabeda/sidekiq.rb
+++ b/lib/yabeda/sidekiq.rb
@@ -26,6 +26,7 @@ module Yabeda
       group :sidekiq
 
       counter :jobs_enqueued_total, tags: %i[queue worker], comment: "A counter of the total number of jobs sidekiq enqueued."
+      counter :jobs_rerouted_total, tags: %i[queue worker], comment: "A counter of the total number of rerouted jobs sidekiq enqueued."
 
       if config.declare_process_metrics # defaults to +::Sidekiq.server?+
         counter   :jobs_executed_total,  tags: %i[queue worker], comment: "A counter of the total number of jobs sidekiq executed."

--- a/lib/yabeda/sidekiq.rb
+++ b/lib/yabeda/sidekiq.rb
@@ -55,7 +55,8 @@ module Yabeda
         gauge     :jobs_retry_count,     tags: [],        aggregation: :most_recent, comment: "The number of failed jobs waiting to be retried"
         gauge     :jobs_dead_count,      tags: [],        aggregation: :most_recent, comment: "The number of jobs exceeded their retry count."
         gauge     :active_processes,     tags: [],        aggregation: :most_recent, comment: "The number of active Sidekiq worker processes."
-        gauge     :queue_latency,        tags: %i[queue], aggregation: :most_recent, comment: "The queue latency, the difference in seconds since the oldest job in the queue was enqueued"
+        gauge     :queue_latency,        tags: %i[queue], aggregation: :most_recent,
+                                         comment: "The queue latency, the difference in seconds since the oldest job in the queue was enqueued"
       end
 
       collect do

--- a/lib/yabeda/sidekiq/client_middleware.rb
+++ b/lib/yabeda/sidekiq/client_middleware.rb
@@ -8,9 +8,9 @@ module Yabeda
         labels = Yabeda::Sidekiq.labelize(worker, job, job["queue"] || queue)
         Yabeda.sidekiq_jobs_enqueued_total.increment(labels)
 
-        if job["queue"] != queue
+        if job["queue"] && job["queue"] != queue
           labels = Yabeda::Sidekiq.labelize(worker, job, queue)
-          Yabeda.sidekiq_jobs_rerouted_total.increment(labels)
+          Yabeda.sidekiq_jobs_rerouted_total.increment({ from_queue: queue, to_queue: job["queue"], **labels.except(:queue) })
         end
 
         yield

--- a/lib/yabeda/sidekiq/client_middleware.rb
+++ b/lib/yabeda/sidekiq/client_middleware.rb
@@ -5,8 +5,14 @@ module Yabeda
     # Client middleware to count number of enqueued jobs
     class ClientMiddleware
       def call(worker, job, queue, _redis_pool)
-        labels = Yabeda::Sidekiq.labelize(worker, job, queue)
+        labels = Yabeda::Sidekiq.labelize(worker, job, job["queue"] || queue)
         Yabeda.sidekiq_jobs_enqueued_total.increment(labels)
+
+        if job["queue"] != queue
+          labels = Yabeda::Sidekiq.labelize(worker, job, queue)
+          Yabeda.sidekiq_jobs_rerouted_total.increment(labels)
+        end
+
         yield
       end
     end

--- a/spec/support/jobs.rb
+++ b/spec/support/jobs.rb
@@ -52,3 +52,11 @@ class FailingActiveJob < ActiveJob::Base
     raise "Boom"
   end
 end
+
+class ReRouteJobsMiddleware
+  def call(_worker, job, _queue, _redis_pool)
+    job["queue"] = "rerouted_queue"
+
+    yield
+  end
+end

--- a/spec/yabeda/sidekiq_spec.rb
+++ b/spec/yabeda/sidekiq_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe Yabeda::Sidekiq do
           { queue: "rerouted_queue", worker: "FailingPlainJob" } => 1,
         )
         expect(Yabeda.sidekiq.jobs_rerouted_total.values).to include(
-          { queue: "default", worker: "SamplePlainJob" } => 2,
-          { queue: "default", worker: "FailingPlainJob" } => 1,
+          { from_queue: "default", to_queue: "rerouted_queue", worker: "SamplePlainJob" } => 2,
+          { from_queue: "default", to_queue: "rerouted_queue", worker: "FailingPlainJob" } => 1,
         )
       end
     end
@@ -111,7 +111,7 @@ RSpec.describe Yabeda::Sidekiq do
           { queue: "rerouted_queue", worker: "SampleActiveJob" } => 1,
         )
         expect(Yabeda.sidekiq.jobs_rerouted_total.values).to include(
-          { queue: "default", worker: "SampleActiveJob" } => 1,
+          { from_queue: "default", to_queue: "rerouted_queue", worker: "SampleActiveJob" } => 1,
         )
       end
     end

--- a/spec/yabeda/sidekiq_spec.rb
+++ b/spec/yabeda/sidekiq_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Yabeda::Sidekiq do
   describe "plain Sidekiq jobs" do
     it "counts enqueues" do
       Yabeda.sidekiq.jobs_enqueued_total.values.clear # This is a hack
+      Yabeda.sidekiq.jobs_rerouted_total.values.clear # This is a hack
 
       SamplePlainJob.perform_async
       SamplePlainJob.perform_async
@@ -21,6 +22,34 @@ RSpec.describe Yabeda::Sidekiq do
         { queue: "default", worker: "SamplePlainJob" } => 2,
         { queue: "default", worker: "FailingPlainJob" } => 1,
       )
+
+      expect(Yabeda.sidekiq.jobs_rerouted_total.values).to be_empty
+    end
+
+    describe "re-routing jobs by middleware" do
+      around do |example|
+        add_reroute_jobs_middleware
+        example.run
+        remove_reroute_jobs_middleware
+      end
+
+      it "counts enqueues" do
+        Yabeda.sidekiq.jobs_enqueued_total.values.clear # This is a hack
+        Yabeda.sidekiq.jobs_rerouted_total.values.clear # This is a hack
+
+        SamplePlainJob.perform_async
+        SamplePlainJob.perform_async
+        FailingPlainJob.perform_async
+
+        expect(Yabeda.sidekiq.jobs_enqueued_total.values).to include(
+          { queue: "rerouted_queue", worker: "SamplePlainJob" } => 2,
+          { queue: "rerouted_queue", worker: "FailingPlainJob" } => 1,
+        )
+        expect(Yabeda.sidekiq.jobs_rerouted_total.values).to include(
+          { queue: "default", worker: "SamplePlainJob" } => 2,
+          { queue: "default", worker: "FailingPlainJob" } => 1,
+        )
+      end
     end
 
     it "measures runtime" do
@@ -59,10 +88,32 @@ RSpec.describe Yabeda::Sidekiq do
   describe "ActiveJob jobs" do
     it "counts enqueues" do
       Yabeda.sidekiq.jobs_enqueued_total.values.clear # This is a hack
+      Yabeda.sidekiq.jobs_rerouted_total.values.clear # This is a hack
       SampleActiveJob.perform_later
       expect(Yabeda.sidekiq.jobs_enqueued_total.values).to include(
         { queue: "default", worker: "SampleActiveJob" } => 1,
       )
+      expect(Yabeda.sidekiq.jobs_rerouted_total.values).to be_empty
+    end
+
+    describe "re-routing jobs by middleware" do
+      around do |example|
+        add_reroute_jobs_middleware
+        example.run
+        remove_reroute_jobs_middleware
+      end
+
+      it "counts enqueues" do
+        Yabeda.sidekiq.jobs_enqueued_total.values.clear # This is a hack
+        Yabeda.sidekiq.jobs_rerouted_total.values.clear # This is a hack
+        SampleActiveJob.perform_later
+        expect(Yabeda.sidekiq.jobs_enqueued_total.values).to include(
+          { queue: "rerouted_queue", worker: "SampleActiveJob" } => 1,
+        )
+        expect(Yabeda.sidekiq.jobs_rerouted_total.values).to include(
+          { queue: "default", worker: "SampleActiveJob" } => 1,
+        )
+      end
     end
 
     it "measures runtime" do
@@ -203,6 +254,22 @@ RSpec.describe Yabeda::Sidekiq do
           { queue: "default", worker: "SampleLongRunningJob" } => 0,
           { queue: "default", worker: "FailingActiveJob" } => 0,
         )
+      end
+    end
+  end
+
+  def add_reroute_jobs_middleware
+    ::Sidekiq.configure_server do |config|
+      config.client_middleware do |chain|
+        chain.insert_before Yabeda::Sidekiq::ClientMiddleware, ReRouteJobsMiddleware
+      end
+    end
+  end
+
+  def remove_reroute_jobs_middleware
+    ::Sidekiq.configure_server do |config|
+      config.client_middleware do |chain|
+        chain.remove ReRouteJobsMiddleware
       end
     end
   end


### PR DESCRIPTION
Some Sidekiq client middleware can reroute jobs by changing the `job["queue"]` parameter. Therefore, it would be better to use a new (rerouted) queue instead of the original queue in the `sidekiq_jobs_enqueued_total_count` metric.
Also, I added the `sidekiq_jobs_rerouted_total_count` metric for the original queue that will help track the fact of rerouting.