### PR TITLE
Add config option to allow retry count metrics segmented by queue

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,3 +74,6 @@ Style/ExplicitBlockArgument:
 
 Gemspec/RequiredRubyVersion:
   Enabled: false
+
+Metrics/ModuleLength:
+  Max: 200

--- a/README.md
+++ b/README.md
@@ -99,14 +99,15 @@ end
 
 Configuration is handled by [anyway_config] gem. With it you can load settings from environment variables (upcased and prefixed with `YABEDA_SIDEKIQ_`), YAML files, and other sources. See [anyway_config] docs for details.
 
-Config key                | Type     | Default                                                 | Description                                                                                                                                        |
-------------------------- | -------- | ------------------------------------------------------- |----------------------------------------------------------------------------------------------------------------------------------------------------|
-`collect_cluster_metrics` | boolean  | Enabled in Sidekiq worker processes, disabled otherwise | Defines whether this Ruby process should collect and expose metrics representing state of the whole Sidekiq installation (queues, processes, etc). |
-`declare_process_metrics` | boolean  | Enabled in Sidekiq worker processes, disabled otherwise | Declare metrics that are only tracked inside worker process even outside of them. Useful for multiprocess metric collection.                       |
+Config key                   | Type     | Default                                                 | Description                                                                                                                                        |
+---------------------------- | -------- | ------------------------------------------------------- |----------------------------------------------------------------------------------------------------------------------------------------------------|
+`collect_cluster_metrics`    | boolean  | Enabled in Sidekiq worker processes, disabled otherwise | Defines whether this Ruby process should collect and expose metrics representing state of the whole Sidekiq installation (queues, processes, etc). |
+`declare_process_metrics`    | boolean  | Enabled in Sidekiq worker processes, disabled otherwise | Declare metrics that are only tracked inside worker process even outside of them. Useful for multiprocess metric collection.                       |
+`retries_segmented_by_queue` | boolean  | Disabled                                                | Defines wheter retries are segemented by queue or reported as a single metric                                                                      |
 
 # Roadmap (TODO or Help wanted)
 
- - Implement optional segmentation of retry/schedule/dead sets
+ - Implement optional segmentation of schedule/dead sets
 
    It should be disabled by default as it requires to iterate over all jobs in sets and may be very slow on large sets.
 

--- a/lib/yabeda/sidekiq/config.rb
+++ b/lib/yabeda/sidekiq/config.rb
@@ -16,6 +16,10 @@ module Yabeda
 
       # Declare metrics that are only tracked inside worker process even outside them
       attr_config declare_process_metrics: ::Sidekiq.server?
+
+      # Retries are tracked by default as a single metric. If you want to track them separately for each queue, set this to +true+
+      # Disabled by default because it is quite slow if the retry set is large
+      attr_config retries_segmented_by_queue: false
     end
   end
 end


### PR DESCRIPTION
This PR adds a new config option to enable the reporting of `retry_count` segmented by queue.