### PR TITLE
Allow capture of error class when job fails

### DIFF
--- a/lib/yabeda/sidekiq/config.rb
+++ b/lib/yabeda/sidekiq/config.rb
@@ -20,6 +20,9 @@ module Yabeda
       # Retries are tracked by default as a single metric. If you want to track them separately for each queue, set this to +true+
       # Disabled by default because it is quite slow if the retry set is large
       attr_config retries_segmented_by_queue: false
+
+      # If set to a symbol or string, a label will be added to the sidekiq_jobs_failed_total metric with the error class name
+      attr_config label_for_error_class_on_sidekiq_jobs_failed: false
     end
   end
 end

--- a/lib/yabeda/sidekiq/server_middleware.rb
+++ b/lib/yabeda/sidekiq/server_middleware.rb
@@ -6,6 +6,7 @@ module Yabeda
     class ServerMiddleware
       # See https://github.com/mperham/sidekiq/discussions/4971
       JOB_RECORD_CLASS = defined?(::Sidekiq::JobRecord) ? ::Sidekiq::JobRecord : ::Sidekiq::Job
+      DEFAULT_JOB_FAILED_ERROR_LABEL_KEY = "sidekiq_jobs_failed_error_class"
 
       # rubocop: disable Metrics/AbcSize, Metrics/MethodLength:
       def call(worker, job, queue)
@@ -20,8 +21,17 @@ module Yabeda
             yield
           end
           Yabeda.sidekiq_jobs_success_total.increment(labels)
-        rescue Exception # rubocop: disable Lint/RescueException
-          Yabeda.sidekiq_jobs_failed_total.increment(labels)
+        rescue Exception => e # rubocop: disable Lint/RescueException
+          sidekiq_jobs_failed_labels = labels.dup
+          if (config_value = Yabeda::Sidekiq.config.label_for_error_class_on_sidekiq_jobs_failed)
+            label = if config_value.is_a?(Symbol) || config_value.is_a?(String)
+                      config_value
+                    else
+                      DEFAULT_JOB_FAILED_ERROR_LABEL_KEY
+                    end
+            sidekiq_jobs_failed_labels[label] = e.class.name
+          end
+          Yabeda.sidekiq_jobs_failed_total.increment(sidekiq_jobs_failed_labels)
           raise
         ensure
           Yabeda.sidekiq_job_runtime.measure(labels, elapsed(start))

--- a/spec/support/jobs.rb
+++ b/spec/support/jobs.rb
@@ -33,8 +33,10 @@ end
 class FailingPlainJob
   include Sidekiq::Worker
 
+  SpecialError = Class.new(StandardError)
+
   def perform(*_args)
-    raise "Badaboom"
+    raise SpecialError, "Badaboom"
   end
 end
 
@@ -47,9 +49,11 @@ class SampleActiveJob < ActiveJob::Base
 end
 
 class FailingActiveJob < ActiveJob::Base
+  SpecialError = Class.new(StandardError)
+
   self.queue_adapter = :Sidekiq
   def perform(*_args)
-    raise "Boom"
+    raise SpecialError, "Boom"
   end
 end
 

--- a/spec/yabeda/sidekiq_spec.rb
+++ b/spec/yabeda/sidekiq_spec.rb
@@ -23,6 +23,84 @@ RSpec.describe Yabeda::Sidekiq do
         )
     end
 
+    context "when label_for_error_class_on_sidekiq_jobs_failed is set to a Symbol" do
+      around do |example|
+        old_value = described_class.config.label_for_error_class_on_sidekiq_jobs_failed
+        described_class.config.label_for_error_class_on_sidekiq_jobs_failed = :my_error_label
+
+        example.run
+
+        described_class.config.label_for_error_class_on_sidekiq_jobs_failed = old_value
+      end
+
+      it "counts enqueues and uses the specified label for the error class", sidekiq: :inline do
+        expect do
+          SamplePlainJob.perform_async
+          SamplePlainJob.perform_async
+          begin
+            FailingPlainJob.perform_async
+          rescue StandardError
+            nil
+          end
+        end.to \
+          increment_yabeda_counter(Yabeda.sidekiq.jobs_failed_total).with(
+            { queue: "default", worker: "FailingPlainJob", my_error_label: "FailingPlainJob::SpecialError" } => 1,
+          )
+      end
+    end
+
+    context "when label_for_error_class_on_sidekiq_jobs_failed is set to a String" do
+      around do |example|
+        old_value = described_class.config.label_for_error_class_on_sidekiq_jobs_failed
+        described_class.config.label_for_error_class_on_sidekiq_jobs_failed = "my-error-label"
+
+        example.run
+
+        described_class.config.label_for_error_class_on_sidekiq_jobs_failed = old_value
+      end
+
+      it "counts failures using the specified label for the error class", sidekiq: :inline do
+        expect do
+          SamplePlainJob.perform_async
+          SamplePlainJob.perform_async
+          begin
+            FailingPlainJob.perform_async
+          rescue StandardError
+            nil
+          end
+        end.to \
+          increment_yabeda_counter(Yabeda.sidekiq.jobs_failed_total).with(
+            { queue: "default", worker: "FailingPlainJob", "my-error-label" => "FailingPlainJob::SpecialError" } => 1,
+          )
+      end
+    end
+
+    context "when label_for_error_class_on_sidekiq_jobs_failed is set to true" do
+      around do |example|
+        old_value = described_class.config.label_for_error_class_on_sidekiq_jobs_failed
+        described_class.config.label_for_error_class_on_sidekiq_jobs_failed = true
+
+        example.run
+
+        described_class.config.label_for_error_class_on_sidekiq_jobs_failed = old_value
+      end
+
+      it "counts enqueues and uses the default label for the error class", sidekiq: :inline do
+        expect do
+          SamplePlainJob.perform_async
+          SamplePlainJob.perform_async
+          begin
+            FailingPlainJob.perform_async
+          rescue StandardError
+            nil
+          end
+        end.to \
+          increment_yabeda_counter(Yabeda.sidekiq.jobs_failed_total).with(
+            { queue: "default", worker: "FailingPlainJob", "sidekiq_jobs_failed_error_class" => "FailingPlainJob::SpecialError" } => 1,
+          )
+      end
+    end
+
     describe "re-routing jobs by middleware" do
       around do |example|
         add_reroute_jobs_middleware
@@ -97,6 +175,84 @@ RSpec.describe Yabeda::Sidekiq do
             increment_yabeda_counter(Yabeda.sidekiq.jobs_rerouted_total).with(
               { from_queue: "default", to_queue: "rerouted_queue", worker: "SampleActiveJob" } => 1,
             )
+      end
+    end
+
+    context "when label_for_error_class_on_sidekiq_jobs_failed is set to a Symbol" do
+      around do |example|
+        old_value = described_class.config.label_for_error_class_on_sidekiq_jobs_failed
+        described_class.config.label_for_error_class_on_sidekiq_jobs_failed = :my_error_label
+
+        example.run
+
+        described_class.config.label_for_error_class_on_sidekiq_jobs_failed = old_value
+      end
+
+      it "counts enqueues and uses the specified label for the error class", sidekiq: :inline do
+        expect do
+          SampleActiveJob.perform_later
+          SampleActiveJob.perform_later
+          begin
+            FailingActiveJob.perform_later
+          rescue StandardError
+            nil
+          end
+        end.to \
+          increment_yabeda_counter(Yabeda.sidekiq.jobs_failed_total).with(
+            { queue: "default", worker: "FailingActiveJob", my_error_label: "FailingActiveJob::SpecialError" } => 1,
+          )
+      end
+    end
+
+    context "when label_for_error_class_on_sidekiq_jobs_failed is set to a String" do
+      around do |example|
+        old_value = described_class.config.label_for_error_class_on_sidekiq_jobs_failed
+        described_class.config.label_for_error_class_on_sidekiq_jobs_failed = "my-error-label"
+
+        example.run
+
+        described_class.config.label_for_error_class_on_sidekiq_jobs_failed = old_value
+      end
+
+      it "counts failures using the specified label for the error class", sidekiq: :inline do
+        expect do
+          SampleActiveJob.perform_later
+          SampleActiveJob.perform_later
+          begin
+            FailingActiveJob.perform_later
+          rescue StandardError
+            nil
+          end
+        end.to \
+          increment_yabeda_counter(Yabeda.sidekiq.jobs_failed_total).with(
+            { queue: "default", worker: "FailingActiveJob", "my-error-label" => "FailingActiveJob::SpecialError" } => 1,
+          )
+      end
+    end
+
+    context "when label_for_error_class_on_sidekiq_jobs_failed is set to true" do
+      around do |example|
+        old_value = described_class.config.label_for_error_class_on_sidekiq_jobs_failed
+        described_class.config.label_for_error_class_on_sidekiq_jobs_failed = true
+
+        example.run
+
+        described_class.config.label_for_error_class_on_sidekiq_jobs_failed = old_value
+      end
+
+      it "counts enqueues and uses the default label for the error class", sidekiq: :inline do
+        expect do
+          SampleActiveJob.perform_later
+          SampleActiveJob.perform_later
+          begin
+            FailingActiveJob.perform_later
+          rescue StandardError
+            nil
+          end
+        end.to \
+          increment_yabeda_counter(Yabeda.sidekiq.jobs_failed_total).with(
+            { queue: "default", worker: "FailingActiveJob", "sidekiq_jobs_failed_error_class" => "FailingActiveJob::SpecialError" } => 1,
+          )
       end
     end
 


### PR DESCRIPTION
This gem captures failed jobs with the jobs_failed_total metric, but does not provide a way to add a label for the error class, which can be useful. This commit allows developers to optionally include a label with the error class on the jobs_failed_total metric.