### PR TITLE
Allow capture of error class when job fails

### DIFF
--- a/lib/yabeda/sidekiq.rb
+++ b/lib/yabeda/sidekiq.rb
@@ -29,9 +29,11 @@ module Yabeda
       counter :jobs_rerouted_total, tags: %i[from_queue to_queue worker], comment: "A counter of the total number of rerouted jobs sidekiq enqueued."
 
       if config.declare_process_metrics # defaults to +::Sidekiq.server?+
+        failed_total_tags = config.label_for_error_class_on_sidekiq_jobs_failed ? %i[queue worker error] : %i[queue worker]
+
         counter   :jobs_executed_total,  tags: %i[queue worker], comment: "A counter of the total number of jobs sidekiq executed."
         counter   :jobs_success_total,   tags: %i[queue worker], comment: "A counter of the total number of jobs successfully processed by sidekiq."
-        counter   :jobs_failed_total,    tags: %i[queue worker], comment: "A counter of the total number of jobs failed in sidekiq."
+        counter   :jobs_failed_total,    tags: failed_total_tags, comment: "A counter of the total number of jobs failed in sidekiq."
 
         gauge     :running_job_runtime,  tags: %i[queue worker], aggregation: :max, unit: :seconds,
                                          comment: "How long currently running jobs are running (useful for detection of hung jobs)"

--- a/lib/yabeda/sidekiq/config.rb
+++ b/lib/yabeda/sidekiq/config.rb
@@ -20,6 +20,9 @@ module Yabeda
       # Retries are tracked by default as a single metric. If you want to track them separately for each queue, set this to +true+
       # Disabled by default because it is quite slow if the retry set is large
       attr_config retries_segmented_by_queue: false
+
+      # If set to true, an `:error` label will be added with name of the error class to all failed jobs
+      attr_config label_for_error_class_on_sidekiq_jobs_failed: false
     end
   end
 end

--- a/spec/support/jobs.rb
+++ b/spec/support/jobs.rb
@@ -33,8 +33,10 @@ end
 class FailingPlainJob
   include Sidekiq::Worker
 
+  SpecialError = Class.new(StandardError)
+
   def perform(*_args)
-    raise "Badaboom"
+    raise SpecialError, "Badaboom"
   end
 end
 
@@ -47,9 +49,11 @@ class SampleActiveJob < ActiveJob::Base
 end
 
 class FailingActiveJob < ActiveJob::Base
+  SpecialError = Class.new(StandardError)
+
   self.queue_adapter = :Sidekiq
   def perform(*_args)
-    raise "Boom"
+    raise SpecialError, "Boom"
   end
 end
 


### PR DESCRIPTION
This gem captures failed jobs with the jobs_failed_total metric, but does not provide a way to add an error label for the error's class, which can be useful. This commit allows developers to optionally include a label with the error class on the jobs_failed_total metric.