### PR TITLE
Adds metrics on how different queues have different thread amounts allocated to them

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,12 @@ Metrics representing state of the whole Sidekiq installation (queues, processes,
  - Number of jobs in retry set: `sidekiq_jobs_retry_count`
  - Number of jobs in dead set (“morgue”): `sidekiq_jobs_dead_count`
  - Active processes count: `sidekiq_active_processes`
- - Active servers count: `sidekiq_active_workers_count`
+ - Active worker threads count: `sidekiq_active_workers_count`
+ - Busy worker threads count: `sidekiq_busy_workers_count`
+ - Available worker threads count: `sidekiq_available_workers_count`
+ - Active worker threads count per queue: `sidekiq_active_workers_count_per_queue` (segmented by queue)
+ - Busy worker threads count per queue: `sidekiq_busy_workers_count_per_queue` (segmented by queue)
+ - Available worker threads count per queue: `sidekiq_available_workers_count_per_queue` (segmented by queue)
 
 By default all sidekiq worker processes (servers) collects global metrics about whole Sidekiq installation. This can be overridden by setting `collect_cluster_metrics` config key to `true` for non-Sidekiq processes or to `false` for Sidekiq processes (e.g. by setting `YABEDA_SIDEKIQ_COLLECT_CLUSTER_METRICS` env variable to `no`, see other methods in [anyway_config] docs).
 

--- a/spec/yabeda/sidekiq_spec.rb
+++ b/spec/yabeda/sidekiq_spec.rb
@@ -253,9 +253,9 @@ RSpec.describe Yabeda::Sidekiq do
 
     it "collects named queues stats", :aggregate_failures do
       expect { Yabeda.collect! }.to \
-        update_yabeda_gauge(Yabeda.sidekiq.jobs_retry_count).with(1).and \
-          update_yabeda_gauge(Yabeda.sidekiq.jobs_dead_count).with(3).and \
-            update_yabeda_gauge(Yabeda.sidekiq.jobs_scheduled_count).with(2)
+        update_yabeda_gauge(Yabeda.sidekiq.jobs_retry_count).with({} => 1).and \
+          update_yabeda_gauge(Yabeda.sidekiq.jobs_dead_count).with({} => 3).and \
+            update_yabeda_gauge(Yabeda.sidekiq.jobs_scheduled_count).with({} => 2)
     end
 
     it "measures maximum runtime of currently running jobs", sidekiq: :inline do

--- a/spec/yabeda/sidekiq_spec.rb
+++ b/spec/yabeda/sidekiq_spec.rb
@@ -233,6 +233,13 @@ RSpec.describe Yabeda::Sidekiq do
           OpenStruct.new({ name: "mailers", latency: 0 }),
         ],
       )
+      allow(Sidekiq::ProcessSet).to receive(:new).and_return(
+        [
+          OpenStruct.new({ concurrency: 2, busy: 1, queues: ['default', 'low'] }),
+          OpenStruct.new({ concurrency: 2, busy: 0, queues: ['default', 'low'] }),
+          OpenStruct.new({ concurrency: 6, busy: 3, queues: ['medium'] }),
+        ]
+      )
     end
 
     it "collects queue latencies" do
@@ -256,6 +263,28 @@ RSpec.describe Yabeda::Sidekiq do
         update_yabeda_gauge(Yabeda.sidekiq.jobs_retry_count).with({} => 1).and \
           update_yabeda_gauge(Yabeda.sidekiq.jobs_dead_count).with({} => 3).and \
             update_yabeda_gauge(Yabeda.sidekiq.jobs_scheduled_count).with({} => 2)
+    end
+
+    it "collects process metrics" do
+      expect { Yabeda.collect! }.to \
+        update_yabeda_gauge(Yabeda.sidekiq.active_workers_count).with({} => 10).and \
+          update_yabeda_gauge(Yabeda.sidekiq.busy_workers_count).with({} => 4).and \
+            update_yabeda_gauge(Yabeda.sidekiq.available_workers_count).with({} => 6).and \
+              update_yabeda_gauge(Yabeda.sidekiq.active_workers_count_per_queue).with(
+                { queue: 'default' } => 4,
+                { queue: 'low' } => 4,
+                { queue: 'medium' } => 6
+              ).and \
+                update_yabeda_gauge(Yabeda.sidekiq.busy_workers_count_per_queue).with(
+                  { queue: 'default' } => 1,
+                  { queue: 'low' } => 1,
+                  { queue: 'medium' } => 3
+                ).and \
+                  update_yabeda_gauge(Yabeda.sidekiq.available_workers_count_per_queue).with(
+                    { queue: 'default' } => 3,
+                    { queue: 'low' } => 3,
+                    { queue: 'medium' } => 3
+                  )
     end
 
     it "measures maximum runtime of currently running jobs", sidekiq: :inline do


### PR DESCRIPTION
# Problem

Latency is great to measure workloads that are starving for resources, but some workloads are critical and we want to be able to see that a problem is forming before it starts. 
How can we measure how can we measure if a given queue is about to "starve" for resources?

# Idea

Measure how busy are the threads able to process a given queue.
If many threads are available then everything is fine, but once more and more threads become busy less available capacity we have for the queue until we reach a point where all threads are busy and we start to form a backlog.

# Proposed Solution

Extract metrics from `::Sidekiq::ProcessSet`.
`::Sidekiq::ProcessSet` gives a set of Process. Each process has the list of queues it's processing and how busy its threads are. From it we can just aggregate the information.