### PR TITLE
Add sidekiq_process_threads gauge (per-process configured concurrency)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
+- `sidekiq_process_threads` gauge reporting the configured thread count (concurrency) of each Sidekiq worker process.
+
+  Unlike `sidekiq_active_workers_count` (which reports a single cluster-wide total of busy threads), this metric is segmented per process via `hostname`, `pid`, and a comma-joined `queues` label listing the queues the process pulls jobs from.
+
 ## 0.12.0 - 2024-03-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Metrics representing state of current Sidekiq worker process and stats of execut
  - Time of job run: `sidekiq_job_runtime` (seconds per job execution, segmented by queue and class name)
  - Time of the job latency `sidekiq_job_latency` (the difference in seconds since the enqueuing until running job)
  - Maximum runtime of currently executing jobs: `sidekiq_running_job_runtime` (useful for detection of hung jobs, segmented by queue and class name)
+ - Number of threads (configured concurrency) of each worker process: `sidekiq_process_threads` (segmented by `hostname`, `pid`, and the comma-joined list of `queues` the process pulls jobs from)
+
+   Because this metric is segmented by `pid`, every restarted or redeployed worker produces a new time series. When a process disappears (its Sidekiq heartbeat expires after ~60 seconds) its series simply stops updating rather than being reset, so treat a missing/stale series as “process gone” (cross-reference `sidekiq_active_processes`) and keep label cardinality in mind on clusters that deploy frequently.
 
 ### Global cluster-wide metrics
 

--- a/lib/yabeda/sidekiq.rb
+++ b/lib/yabeda/sidekiq.rb
@@ -62,6 +62,8 @@ module Yabeda
         gauge     :active_processes,     tags: [],               aggregation: :most_recent, comment: "The number of active Sidekiq worker processes."
         gauge     :queue_latency,        tags: %i[queue],        aggregation: :most_recent,
                                          comment: "The queue latency, the difference in seconds since the oldest job in the queue was enqueued"
+        gauge     :process_threads,      tags: %i[hostname pid queues], aggregation: :most_recent,
+                                         comment: "Configured thread count (concurrency) of each Sidekiq worker process, by hostname, pid, and queues."
       end
 
       collect do
@@ -78,6 +80,20 @@ module Yabeda
         sidekiq_jobs_scheduled_count.set({}, stats.scheduled_size)
         sidekiq_jobs_dead_count.set({}, stats.dead_size)
         sidekiq_active_processes.set({}, stats.processes_size)
+
+        ::Sidekiq::ProcessSet.new.each do |process|
+          sidekiq_process_threads.set(
+            {
+              hostname: process["hostname"],
+              pid: process["pid"],
+              # Read the +queues+ attribute rather than calling +process.queues+: the latter is
+              # not defined on Sidekiq < 6.2.2, while this attribute is present in the heartbeat info
+              # on every supported version (capsules-derived and de-duplicated since Sidekiq 8.0.8).
+              queues: Array(process["queues"]).sort.join(","),
+            },
+            process["concurrency"],
+          )
+        end
 
         ::Sidekiq::Queue.all.each do |queue|
           sidekiq_queue_latency.set({ queue: queue.name }, queue.latency)

--- a/spec/yabeda/sidekiq_spec.rb
+++ b/spec/yabeda/sidekiq_spec.rb
@@ -233,6 +233,12 @@ RSpec.describe Yabeda::Sidekiq do
           OpenStruct.new({ name: "mailers", latency: 0 }),
         ],
       )
+      allow(Sidekiq::ProcessSet).to receive(:new).and_return(
+        [
+          OpenStruct.new(hostname: "host-1", pid: 100, concurrency: 5, queues: %w[mailers default]),
+          OpenStruct.new(hostname: "host-2", pid: 200, concurrency: 10, queues: %w[low]),
+        ],
+      )
     end
 
     it "collects queue latencies" do
@@ -256,6 +262,14 @@ RSpec.describe Yabeda::Sidekiq do
         update_yabeda_gauge(Yabeda.sidekiq.jobs_retry_count).with(1).and \
           update_yabeda_gauge(Yabeda.sidekiq.jobs_dead_count).with(3).and \
             update_yabeda_gauge(Yabeda.sidekiq.jobs_scheduled_count).with(2)
+    end
+
+    it "collects per-process thread counts segmented by host, pid, and queues" do
+      expect { Yabeda.collect! }.to \
+        update_yabeda_gauge(Yabeda.sidekiq.process_threads).with(
+          { hostname: "host-1", pid: 100, queues: "default,mailers" } => 5,
+          { hostname: "host-2", pid: 200, queues: "low" } => 10,
+        )
     end
 
     it "measures maximum runtime of currently running jobs", sidekiq: :inline do


### PR DESCRIPTION
## Background

The only existing thread-related metric is `sidekiq_active_workers_count`, which is a single cluster-wide total of *busy* threads (`Sidekiq::Stats#workers_size`). That aggregate can't tell you:

- how many threads any individual worker process is configured to run, or
- how thread capacity is distributed across hosts/processes and the queues they serve.

This is useful for fleets running heterogeneous Sidekiq processes (different concurrency/queues per process) and for anyone observing or tuning thread-pool sizes per process.

## What

This PR adds a new gauge, `sidekiq_process_threads`, reporting the configured thread pool size (concurrency) of each Sidekiq worker process, segmented by `hostname`, `pid`, and a comma-joined `queues` label listing the queues the process pulls jobs from.

## How

Collected in the existing cluster-metrics `collect` block by iterating `Sidekiq::ProcessSet`, reporting each process's `concurrency` keyed by `hostname` / `pid` / `queues`. The existing `sidekiq_active_workers_count` is left untouched, so this is purely additive.

The queue list is read from the `process["queues"]` heartbeat **attribute** rather than `Sidekiq::Process#queues`: the method doesn't exist before Sidekiq 6.2.2 and would raise `NoMethodError`, whereas the attribute is present (capsules-derived and de-duplicated since 8.0.8) on every supported version. The accessor and `ProcessSet#each` were verified against real Sidekiq sources back to 3.0.

## Notes for reviewers

- It's documented under **Local per-process metrics** because each time series describes a single process — but, like the other cluster metrics, it's collected by reading `Sidekiq::ProcessSet` from Redis and is therefore gated on `collect_cluster_metrics`. Happy to move it to the cluster-wide section (or change the gating) if you'd prefer.
- It adds one `ProcessSet` read per collection/scrape, alongside the `Stats`/`Queue` reads already in that block.
- `pid` is part of the label set, so restarts/redeploys create new series over time (called out in the README).

## Tests / docs

- Added a spec covering the per-process values (stubs `Sidekiq::ProcessSet`).
- README (Local per-process metrics) and CHANGELOG updated.
- `rake spec` passes; RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
